### PR TITLE
Fixed return statement at types.d#L88

### DIFF
--- a/source/schemed/types.d
+++ b/source/schemed/types.d
@@ -85,7 +85,7 @@ bool toBool(Atom atom)
     bool* b = atom.peek!bool();
 
     if (b is null)
-        return Atom(true);
+        return true;
 
     return *b;
 }


### PR DESCRIPTION
The return statement of the function is `bool`, but an `Atom` is being returned.
